### PR TITLE
Implemented sliding subtitle text into another subtitle,

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,6 +361,7 @@ plugins/actions/removesubtitle/Makefile
 plugins/actions/reversetextandtranslation/Makefile
 plugins/actions/scalesubtitles/Makefile
 plugins/actions/selection/Makefile
+plugins/actions/slidetimings/Makefile
 plugins/actions/sortsubtitles/Makefile
 plugins/actions/spellchecking/Makefile
 plugins/actions/splitdocument/Makefile

--- a/plugins/actions/Makefile.am
+++ b/plugins/actions/Makefile.am
@@ -31,6 +31,7 @@ FILES = \
 		reversetextandtranslation \
 		scalesubtitles \
 		selection \
+		slidetimings \
 		sortsubtitles \
 		spellchecking \
 		splitdocument \

--- a/plugins/actions/slidetimings/Makefile.am
+++ b/plugins/actions/slidetimings/Makefile.am
@@ -1,0 +1,25 @@
+pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
+plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src \
+	$(SUBTITLEEDITOR_CFLAGS)
+
+pluginlib_LTLIBRARIES = \
+	libslidetimings.la
+
+libslidetimings_la_SOURCES = \
+	slidetimings.cc
+
+libslidetimings_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
+libslidetimings_la_LIBADD = $(SUBTITLEEDITOR_LIBS) -L$(top_srcdir)/src -lsubtitleeditor
+
+plugindescription_in_files = slidetimings.se-plugin.in
+plugindescription_DATA = $(plugindescription_in_files:.se-plugin.in=.se-plugin)
+
+@INTLTOOL_SE_PLUGIN_RULE@
+
+EXTRA_DIST = $(plugindescription_in_files)
+
+CLEANFILES = $(plugindescription_DATA) Makefile.am~ *.cc~ *.h~ *.in~

--- a/plugins/actions/slidetimings/slidetimings.cc
+++ b/plugins/actions/slidetimings/slidetimings.cc
@@ -1,7 +1,8 @@
 /*
  *
  *	slidetimings.cc
- *	- "justice for selected subtitles"
+ *	- "slide subtitle text up and down between subtitles
+ *     while keeping the timings in place"
  *	a subtitleeditor plugin by Eltomito <tomaspartl@centrum.cz>
  *
  *	subtitleeditor -- a tool to create or edit subtitle
@@ -55,12 +56,12 @@ public:
 		action_group = Gtk::ActionGroup::create("SlideTimingsPlugin");
 
 		action_group->add(
-				Gtk::Action::create("bump-up", _("_Bump Text Up"),
+				Gtk::Action::create("bump-up", _("Bump Text Up"),
 				_("Moves the text field to the previous subtitle for all subtitles from the current one to the end.")),
 					sigc::mem_fun(*this, &SlideTimingsPlugin::on_bump_up));
 
 		action_group->add(
-				Gtk::Action::create("bump-down", _("_Bump Text Down"),
+				Gtk::Action::create("bump-down", _("Bump Text Down"),
 				_("Moves the text field to the next subtitle for all subtitles from the current one to the end.")),
 					sigc::mem_fun(*this, &SlideTimingsPlugin::on_bump_down));
 

--- a/plugins/actions/slidetimings/slidetimings.cc
+++ b/plugins/actions/slidetimings/slidetimings.cc
@@ -1,0 +1,196 @@
+/*
+ *
+ *	slidetimings.cc
+ *	- "justice for selected subtitles"
+ *	a subtitleeditor plugin by Eltomito <tomaspartl@centrum.cz>
+ *
+ *	subtitleeditor -- a tool to create or edit subtitle
+ *
+ *	https://kitone.github.io/subtitleeditor/
+ *	https://github.com/kitone/subtitleeditor/
+ *
+ *	Copyright @ 2005-2012, kitone
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include <extension/action.h>
+#include <i18n.h>
+#include <debug.h>
+#include <utility.h>
+
+class SlideTimingsPlugin : public Action
+{
+public:
+
+	SlideTimingsPlugin()
+	{
+		activate();
+		update_ui();
+	}
+
+	~SlideTimingsPlugin()
+	{
+		deactivate();
+	}
+
+	/*
+	 */
+	void activate()
+	{
+		se_dbg(SE_DBG_PLUGINS);
+
+		// actions
+		action_group = Gtk::ActionGroup::create("SlideTimingsPlugin");
+
+		action_group->add(
+				Gtk::Action::create("bump-up", _("_Bump Text Up"),
+				_("Moves the text field to the previous subtitle for all subtitles from the current one to the end.")),
+					sigc::mem_fun(*this, &SlideTimingsPlugin::on_bump_up));
+
+		action_group->add(
+				Gtk::Action::create("bump-down", _("_Bump Text Down"),
+				_("Moves the text field to the next subtitle for all subtitles from the current one to the end.")),
+					sigc::mem_fun(*this, &SlideTimingsPlugin::on_bump_down));
+
+		// ui
+		Glib::RefPtr<Gtk::UIManager> ui = get_ui_manager();
+
+		ui_id = ui->new_merge_id();
+
+		ui->insert_action_group(action_group);
+
+		ui->add_ui(ui_id, "/menubar/menu-timings/bump-up", "bump-up", "bump-up");
+		ui->add_ui(ui_id, "/menubar/menu-timings/bump-down", "bump-down", "bump-down");
+	}
+
+	/*
+	 */
+	void deactivate()
+	{
+		se_dbg(SE_DBG_PLUGINS);
+
+		Glib::RefPtr<Gtk::UIManager> ui = get_ui_manager();
+
+		ui->remove_ui(ui_id);
+		ui->remove_action_group(action_group);
+	}
+
+	/*
+	 */
+	void update_ui()
+	{
+		se_dbg(SE_DBG_PLUGINS);
+
+		bool visible = (get_current_document() != NULL);
+
+		action_group->get_action("bump-up")->set_sensitive(visible);
+		action_group->get_action("bump-down")->set_sensitive(visible);
+	}
+
+protected:
+
+	/*
+	 */
+	void on_bump_down()
+	{
+		se_dbg(SE_DBG_PLUGINS);
+
+		Document *doc = get_current_document();
+		g_return_if_fail(doc);
+
+		std::vector<Subtitle> selection = doc->subtitles().get_selection();
+		if(selection.empty())
+		{
+			doc->flash_message(_("Please select at least one subtitle."));
+			return;
+		}
+
+		doc->start_command(_("Bump Down"));
+
+		if( selection.size() == 1 ) {
+			select_to_end( doc, selection );
+      Subtitle overflow = doc->subtitles().insert_after( selection[ selection.size()-1 ] );
+      selection.push_back( overflow );
+		}
+
+		creep_to_pos( selection.rbegin(), selection.rend() );
+
+		doc->emit_signal("subtitle-time-changed");
+		doc->finish_command();
+	}
+
+	/*
+	 */
+	void on_bump_up()
+	{
+		se_dbg(SE_DBG_PLUGINS);
+
+		Document *doc = get_current_document();
+		g_return_if_fail(doc);
+
+		std::vector<Subtitle> selection = doc->subtitles().get_selection();
+		if(selection.empty())
+		{
+			doc->flash_message(_("Please select at least one subtitle."));
+			return;
+		}
+
+		doc->start_command(_("Bump Up"));
+
+		if( selection.size() == 1 ) {
+			select_to_end( doc, selection );
+		}
+
+		creep_to_pos( selection.begin(), selection.end() );
+
+		doc->emit_signal("subtitle-time-changed");
+		doc->finish_command();
+	}
+
+	template <class Iterator>
+	void creep_to_pos( Iterator pos, Iterator end )
+	{
+		if( pos == end ) return;
+		Iterator lastpos = pos;
+		++pos;
+		while( pos != end ) {
+			lastpos->set_text( pos->get_text() );
+			++pos;
+			++lastpos;
+		}
+		lastpos->set_text("");
+	}
+
+	/*
+	 * Adds to the selection all the subtitles that come after it in the subtitles in the document. 
+	 */
+	void select_to_end( Document *doc, std::vector<Subtitle> &selection )
+	{
+		Subtitles subtitles = doc->subtitles();
+		Subtitle sub = selection[ selection.size() - 1 ]; 
+		sub = subtitles.get_next( sub );
+		while( sub ) {
+			selection.push_back( sub ); 
+			sub = subtitles.get_next( sub );
+		}
+	}
+
+protected:
+	Gtk::UIManager::ui_merge_id ui_id;
+	Glib::RefPtr<Gtk::ActionGroup> action_group;
+};
+
+REGISTER_EXTENSION(SlideTimingsPlugin)
+

--- a/plugins/actions/slidetimings/slidetimings.se-plugin.in
+++ b/plugins/actions/slidetimings/slidetimings.se-plugin.in
@@ -1,0 +1,7 @@
+[SubtitleEditor Extension]
+_Name=Slide Timings
+_Description=Bumps the text fields of following subtitles up or down with respect to their timings.
+Categorie=action
+Type=module
+Module=slidetimings
+Authors=eltomito <tomaspartl at centrum dot cz>

--- a/share/menubar.xml
+++ b/share/menubar.xml
@@ -73,6 +73,9 @@
 			<placeholder name="stack-subtitles"/>
 			<placeholder name="stack-subtitles-from-end"/>
 			<separator/>
+			<placeholder name="bump-down"/>
+			<placeholder name="bump-up"/>
+			<separator/>
 			<placeholder name="placeholder"/>
 		</menu>
 


### PR DESCRIPTION
This adds two new commands: Bump Text Down and Bump Text Up.
They move the subtitle text into the next or previous subtitle while leaving the timings in place.
This feature is useful when a translator works on a separate copy of the subtitles and joins or splits some subtitles in the process.
It puts the timings out of alignment with the original subtitles in some places and this is a way to fix it.
If a block of subtitles is selected, it only affects the selection.
If one subtitle is selected, all subsequent subtitles are affected.
