### PR TITLE
Make Move subtitles plugin smarter

### DIFF
--- a/plugins/actions/movesubtitles/dialog-move-subtitles.ui
+++ b/plugins/actions/movesubtitles/dialog-move-subtitles.ui
@@ -165,7 +165,7 @@
                             <property name="y_options"/>
                           </packing>
                         </child>
-                        <child>
+                        <!--<child>
                           <object class="GtkCheckButton" id="check-only-selected-subtitles">
                             <property name="label" translatable="yes">_Only selected subtitles</property>
                             <property name="visible">True</property>
@@ -181,7 +181,7 @@
                             <property name="top_attach">2</property>
                             <property name="bottom_attach">3</property>
                           </packing>
-                        </child>
+                        </child><-->
                       </object>
                     </child>
                   </object>

--- a/plugins/actions/movesubtitles/movesubtitles.cc
+++ b/plugins/actions/movesubtitles/movesubtitles.cc
@@ -185,8 +185,8 @@ class MoveSubtitlesPlugin : public Action {
     return true;
   }
 
-  // Used only the first selected subtitles and move all the next
-  // subtitles selected or not.
+  // Move the first selected subtitle and all subsequent subtitles
+  // regardless of selection.
   bool move_first_selected_subtitle_and_next(Document *doc, const long &diff) {
     se_dbg(SE_DBG_PLUGINS);
 

--- a/plugins/actions/movesubtitles/movesubtitles.cc
+++ b/plugins/actions/movesubtitles/movesubtitles.cc
@@ -21,8 +21,11 @@
 #include <extension/action.h>
 #include <gtkmm_utility.h>
 #include <gui/spinbuttontime.h>
+#include <player.h>
+#include <subtitleeditorwindow.h>
 #include <utility.h>
 #include <widget_config_utility.h>
+
 #include <memory>
 
 class DialogMoveSubtitles : public Gtk::Dialog {
@@ -58,7 +61,13 @@ class DialogMoveSubtitles : public Gtk::Dialog {
     m_spinStartValue->set_value(value);
     m_spinStartValue->set_range(value, value);
 
-    m_spinNewStart->set_value(value);
+    // Set the new start of subtitles to current player position
+    long position = value;
+    Player *player = SubtitleEditorWindow::get_instance()->get_player();
+    if (player->get_state() != Player::NONE)
+      position = player->get_position();
+
+    m_spinNewStart->set_value(position);
     m_spinNewStart->grab_focus();
   }
 

--- a/plugins/actions/movesubtitles/movesubtitles.cc
+++ b/plugins/actions/movesubtitles/movesubtitles.cc
@@ -176,6 +176,9 @@ class MoveSubtitlesPlugin : public Action {
 
           doc->emit_signal("subtitle-time-changed");
           doc->finish_command();
+        } else {
+          doc->flash_message(_(
+              "Old Start Time and New Start are the same. Nothing was moved."));
         }
       }
     } else {

--- a/plugins/actions/movesubtitles/movesubtitles.cc
+++ b/plugins/actions/movesubtitles/movesubtitles.cc
@@ -38,12 +38,12 @@ class DialogMoveSubtitles : public Gtk::Dialog {
     builder->get_widget("label-start-value", m_labelStartValue);
     builder->get_widget_derived("spin-start-value", m_spinStartValue);
     builder->get_widget_derived("spin-new-start", m_spinNewStart);
-    builder->get_widget("check-only-selected-subtitles",
-                        m_checkOnlySelectedSubtitles);
+    // builder->get_widget("check-only-selected-subtitles",
+    //                     m_checkOnlySelectedSubtitles);
 
-    widget_config::read_config_and_connect(m_checkOnlySelectedSubtitles,
-                                           "move-subtitles",
-                                           "only-selected-subtitles");
+    // widget_config::read_config_and_connect(m_checkOnlySelectedSubtitles,
+    //                                        "move-subtitles",
+    //                                        "only-selected-subtitles");
   }
 
   void init(Document *doc, const Subtitle &subtitle) {
@@ -73,17 +73,17 @@ class DialogMoveSubtitles : public Gtk::Dialog {
 
   long get_diff_value() {
     return (long)(m_spinNewStart->get_value() - m_spinStartValue->get_value());
-  }
+  }  //
 
-  bool only_selected_subtitles() {
-    return m_checkOnlySelectedSubtitles->get_active();
-  }
+  // bool only_selected_subtitles() {
+  //   return m_checkOnlySelectedSubtitles->get_active();
+  // }
 
  protected:
   Gtk::Label *m_labelStartValue;
   SpinButtonTime *m_spinStartValue;
   SpinButtonTime *m_spinNewStart;
-  Gtk::CheckButton *m_checkOnlySelectedSubtitles;
+  // Gtk::CheckButton *m_checkOnlySelectedSubtitles;
 };
 
 class MoveSubtitlesPlugin : public Action {
@@ -104,10 +104,10 @@ class MoveSubtitlesPlugin : public Action {
     action_group = Gtk::ActionGroup::create("MoveSubtitlesPlugin");
 
     action_group->add(
-        Gtk::Action::create("move-subtitles", Gtk::Stock::JUMP_TO,
-                            _("_Move Subtitles"),
-                            _("All subtitles will be also moved after the "
-                              "first selected subtitle")),
+        Gtk::Action::create(
+            "move-subtitles", Gtk::Stock::JUMP_TO, _("_Move Subtitles"),
+            _("Move selected subtitles. If only one subtitle is selected, move "
+              "it and all subsequent subtitles.")),
         Gtk::AccelKey("<Control>M"),
         sigc::mem_fun(*this, &MoveSubtitlesPlugin::on_move_subtitles));
 
@@ -159,6 +159,7 @@ class MoveSubtitlesPlugin : public Action {
             "dialog-move-subtitles.ui", "dialog-move-subtitles"));
 
     Subtitle first_selected_subtitle = doc->subtitles().get_first_selected();
+    Subtitle last_selected_subtitle = doc->subtitles().get_last_selected();
 
     if (first_selected_subtitle) {
       dialog->init(doc, first_selected_subtitle);
@@ -169,7 +170,8 @@ class MoveSubtitlesPlugin : public Action {
         if (diff != 0) {
           doc->start_command(_("Move Subtitles"));
 
-          if (dialog->only_selected_subtitles())
+          // if (dialog->only_selected_subtitles())
+          if (last_selected_subtitle != first_selected_subtitle)
             move_selected_subtitles(doc, diff);
           else
             move_first_selected_subtitle_and_next(doc, diff);


### PR DESCRIPTION
The details of the changes are in the individual four commits. I think the first three commits are clear improvements.

The last one is an open question if it is a good idea. In my opinion, this is simpler UI and mirrors how I personally use the plugin. But I am not sure if everybody is like me. Another approach would be to add another checkbox "Override what gets moved" (With an explanatory tooltip) that would upon checking activate the current preference. Otherwise the preference would be inactive. That way, the plugin would decide based on selection what to do, unless user overrides it.

I am leaning to the opinion that such UI is too complicated and that use case when one selects multiple subtitles but wants to actually move all of them is not really useful.

Based on discussion, I will either redo the commit so that I will remove the code that is now commented out, or will try to implement what I suggested above.