### PR TITLE
Fix .gitignore (wrong lines sneaked in and vim swap files had one asterisk too many)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,12 +103,8 @@ compile_commands.json
 .cache/*
 *.kate-swp
 
-<<<<<<< HEAD
-=======
 #vim
-*.*.swp
-
->>>>>>> 392b72d (Add vim swap files to .gitignore)
+.*.swp
 
 #lock files
 *.lock


### PR DESCRIPTION
Lines that were not supposed to be there sneaked in and also the vim swap rule had one asterisk too many.