### PR TITLE
Add --force-window=yes to default mpv external player command

### DIFF
--- a/plugins/actions/externalvideoplayer/externalvideoplayer.cc
+++ b/plugins/actions/externalvideoplayer/externalvideoplayer.cc
@@ -217,9 +217,8 @@ class ExternalVideoPlayer : public Action {
       return cfg::get_string("external-video-player", "command");
     }
     // write the default command in the config
-	// 2025: I suspect the below is never called
     auto default_cmd = R"(
-      mpv --sub-file="#subtitle_uri" --start="#time" "#video_uri" --sub-auto=no --osd-level=2
+      mpv --sub-file="#subtitle_uri" --start="#time" "#video_uri" --sub-auto=no --osd-level=2  --force-window=yes
     )";
 
     cfg::set_string("external-video-player", "command", default_cmd);


### PR DESCRIPTION
Without it, when playing an audio file MPV launched without window, making it quite awkward to quit.