### PR TITLE
Join Document Plugin: Add Append action and make offset configurable

### DIFF
--- a/plugins/actions/joindocument/Makefile.am
+++ b/plugins/actions/joindocument/Makefile.am
@@ -1,10 +1,15 @@
+plugin_name = joindocument
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
+actionplugindevdir = plugins/actions/$(plugin_name)
+uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
-	$(SUBTITLEEDITOR_CFLAGS)
+	$(SUBTITLEEDITOR_CFLAGS) \
+	-DSE_PLUGIN_PATH_DEV=\"$(actionplugindevdir)\" \
+	-DSE_PLUGIN_PATH_UI=\"$(uidir)\"
 
 pluginlib_LTLIBRARIES = \
 	libjoindocument.la
@@ -20,6 +25,8 @@ plugindescription_DATA = $(plugindescription_in_files:.se-plugin.in=.se-plugin)
 
 @INTLTOOL_SE_PLUGIN_RULE@
 
-EXTRA_DIST = $(plugindescription_in_files)
+ui_DATA = dialog-join-offset.ui
+
+EXTRA_DIST = $(plugindescription_in_files) $(ui_DATA)
 
 CLEANFILES = $(plugindescription_DATA) Makefile.am~ *.cc~ *.h~ *.in~

--- a/plugins/actions/joindocument/dialog-join-offset.ui
+++ b/plugins/actions/joindocument/dialog-join-offset.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+  </object>
+  <object class="GtkDialog" id="dialog-join-offset">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Join Subtitles</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="cancelbutton1">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="okbutton1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="border_width">12</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkVBox" id="vbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkTable" id="table2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="n_rows">1</property>
+                        <property name="n_columns">2</property>
+                        <property name="column_spacing">6</property>
+                        <property name="row_spacing">6</property>
+                        <child>
+                          <object class="GtkSpinButton" id="spin-offset">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="adjustment">adjustment1</property>
+                            <property name="climb_rate">1</property>
+                            <property name="activates-default">True</property>
+
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="right_attach">2</property>
+                            <property name="top_attach">1</property>
+                            <property name="bottom_attach">2</property>
+                            <property name="x_options">GTK_FILL</property>
+                            <property name="y_options"/>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label-offset">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">_Offset:</property>
+                            <property name="use_underline">True</property>
+                            <property name="tooltip-text" translatable="yes">Subtitles from the new file will be joined with this offset. If a video is open, its duration is offered as offset. If no video is open, the end time of the last subtitle is offered as the offset.</property>
+                          </object>
+                          <packing>
+                            <property name="top_attach">1</property>
+                            <property name="bottom_attach">2</property>
+                            <property name="x_options">GTK_FILL</property>
+                            <property name="y_options"/>
+                          </packing>
+                        </child>
+                       </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">cancelbutton1</action-widget>
+      <action-widget response="-5">okbutton1</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/plugins/actions/joindocument/joindocument.cc
+++ b/plugins/actions/joindocument/joindocument.cc
@@ -20,8 +20,50 @@
 
 #include <debug.h>
 #include <extension/action.h>
+#include <gtkmm_utility.h>
 #include <gui/dialogfilechooser.h>
+#include <gui/spinbuttontime.h>
 #include <i18n.h>
+#include <player.h>
+#include <subtitleeditorwindow.h>
+#include <utility.h>
+#include <widget_config_utility.h>
+
+#include <string>
+
+class DialogJoinOffset : public Gtk::Dialog {
+ public:
+  DialogJoinOffset(BaseObjectType *cobject,
+                   const Glib::RefPtr<Gtk::Builder> &builder)
+      : Gtk::Dialog(cobject) {
+    utility::set_transient_parent(*this);
+    builder->get_widget_derived("spin-offset", m_spinOffset);
+  }
+
+  void init(Document *doc, const Subtitle &last_subtitle) {
+    TIMING_MODE edit_mode = doc->get_edit_timing_mode();
+    m_spinOffset->set_timing_mode(edit_mode);
+
+    long default_offset = 0;
+
+    // Try to prefill with video end time
+    Player *player = SubtitleEditorWindow::get_instance()->get_player();
+    if (player && player->get_state() != Player::NONE)
+      default_offset = std::max<long>(0, player->get_duration());
+    else
+      default_offset = last_subtitle.get_end().totalmsecs;
+
+    m_spinOffset->set_value(static_cast<double>(default_offset));
+    m_spinOffset->grab_focus();
+  }
+
+  long get_offset_value() const {
+    return static_cast<long>(m_spinOffset->get_value());
+  }
+
+ protected:
+  SpinButtonTime *m_spinOffset;
+};
 
 class JoinDocumentPlugin : public Action {
  public:
@@ -41,9 +83,19 @@ class JoinDocumentPlugin : public Action {
     action_group = Gtk::ActionGroup::create("JoinDocumentPlugin");
 
     action_group->add(
-        Gtk::Action::create("join-document", Gtk::Stock::CONNECT,
-                            _("_Join Document"), _("Add subtitles from file")),
-        sigc::mem_fun(*this, &JoinDocumentPlugin::on_execute));
+        Gtk::Action::create(
+            "join-document", Gtk::Stock::CONNECT, _("_Join Document"),
+            _("Add subtitles from a file to the current document, adjusting "
+              "timecodes by given offset. If a video is open, its duration is "
+              "offered as the offset. If no video is open, the end time of the "
+              "last subtitle is offered as the offset.")),
+        sigc::mem_fun(*this, &JoinDocumentPlugin::on_execute_join));
+
+    action_group->add(
+        Gtk::Action::create(
+            "append-document", Gtk::Stock::ADD, _("_Append Document"),
+            _("Append subtitles from file without changing timecodes")),
+        sigc::mem_fun(*this, &JoinDocumentPlugin::on_execute_append));
 
     // ui
     Glib::RefPtr<Gtk::UIManager> ui = get_ui_manager();
@@ -54,6 +106,8 @@ class JoinDocumentPlugin : public Action {
 
     ui->add_ui(ui_id, "/menubar/menu-tools/join-document", "join-document",
                "join-document");
+    ui->add_ui(ui_id, "/menubar/menu-tools/append-document", "append-document",
+               "append-document");
   }
 
   void deactivate() {
@@ -71,81 +125,133 @@ class JoinDocumentPlugin : public Action {
     bool visible = (get_current_document() != NULL);
 
     action_group->get_action("join-document")->set_sensitive(visible);
+    action_group->get_action("append-document")->set_sensitive(visible);
   }
 
  protected:
-  void on_execute() {
+  bool applying_offset;
+  void on_execute_join() {
     se_dbg(SE_DBG_PLUGINS);
-
-    execute();
+    applying_offset = true;
+    execute(applying_offset);
   }
 
-  bool execute() {
+  void on_execute_append() {
+    se_dbg(SE_DBG_PLUGINS);
+    applying_offset = false;
+    execute(applying_offset);
+  }
+
+  bool execute(bool applying_offset) {
     se_dbg(SE_DBG_PLUGINS);
 
     Document *doc = get_current_document();
 
     g_return_val_if_fail(doc, false);
 
+    // Get the original document info before opening the file dialog
+    unsigned int subtitle_size = doc->subtitles().size();
+
     DialogOpenDocument::unique_ptr ui = DialogOpenDocument::create();
 
     ui->show_video(false);
     ui->set_select_multiple(false);
 
-    if (ui->run() == Gtk::RESPONSE_OK) {
-      Glib::ustring uri = ui->get_uri();
-      // tmp document to try to open the file
-      Document *tmp = Document::create_from_file(uri);
-      if (tmp == NULL)
+    if (ui->run() != Gtk::RESPONSE_OK)
+      return false;
+
+    Glib::ustring uri = ui->get_uri();
+
+    // tmp document to try to open the file
+    Document *tmp = Document::create_from_file(uri);
+    if (tmp == NULL)
+      return false;
+
+    ui->hide();  // hides (closes?) the dialog so the next one can display
+
+    Glib::ustring encoding = tmp->getCharset();
+    delete tmp;
+
+    // Declare offset variable outside the if block so it's available later
+    SubtitleTime offset = 0;
+
+    // If we are joining, we ask for offset first, otherwise the subtitles
+    // get joined without offset in the background, which looks ugly
+    if (applying_offset) {
+      // Get the last subtitle of the original document
+      Subtitle last_orig_sub = doc->subtitles().get(subtitle_size);
+
+      // Show offset dialog
+      std::unique_ptr<DialogJoinOffset> offset_dialog(
+          gtkmm_utility::get_widget_derived<DialogJoinOffset>(
+              SE_DEV_VALUE(SE_PLUGIN_PATH_UI, SE_PLUGIN_PATH_DEV),
+              "dialog-join-offset.ui", "dialog-join-offset"));
+
+      offset_dialog->init(doc, last_orig_sub);
+
+      if (offset_dialog->run() == Gtk::RESPONSE_OK) {
+        offset = offset_dialog->get_offset_value();
+      } else {
+        doc->flash_message(_("Join cancelled."));
         return false;
-
-      Glib::ustring ofile = doc->getFilename();
-      Glib::ustring oformat = doc->getFormat();
-      Glib::ustring ocharset = doc->getCharset();
-
-      Glib::ustring encoding = tmp->getCharset();
-
-      delete tmp;
-
-      unsigned int subtitle_size = doc->subtitles().size();
-
-      try {  // needs with Document::open
-        doc->start_command(_("Join document"));
-        doc->setCharset(encoding);
-        doc->open(uri);
-
-        // Moves added subtitles after the last original
-        if (subtitle_size > 0) {
-          // Get the last subtitle of the original document
-          Subtitle last_orig_sub = doc->subtitles().get(subtitle_size);
-          // Get The first subtitle added to the original document
-          Subtitle first_new_subs = doc->subtitles().get_next(last_orig_sub);
-
-          // The offset from the last original sub
-          SubtitleTime offset = last_orig_sub.get_end();
-          for (Subtitle sub = first_new_subs; sub; ++sub) {
-            sub.set_start_and_end(sub.get_start() + offset,
-                                  sub.get_end() + offset);
-          }
-          // Make the user life easy by selecting the first new subtitle
-          doc->subtitles().select(first_new_subs);
-        }
-
-        doc->setFilename(ofile);
-        doc->setFormat(oformat);
-        doc->setCharset(ocharset);
-        doc->finish_command();
-
-        unsigned int subtitles_added = doc->subtitles().size() - subtitle_size;
-
-        doc->flash_message(
-            ngettext("1 subtitle has been added at this document.",
-                     "%d subtitles have been added at this document.",
-                     subtitles_added),
-            subtitles_added);
-      } catch (...) {
-        se_dbg_msg(SE_DBG_PLUGINS, "Failed to join document: %s", uri.c_str());
       }
+    }
+
+    Glib::ustring ofile = doc->getFilename();
+    Glib::ustring oformat = doc->getFormat();
+    Glib::ustring ocharset = doc->getCharset();
+
+    try {  // needs with Document::open
+      doc->start_command(applying_offset ? _("Join document")
+                                         : _("Append document"));
+      doc->setCharset(encoding);
+      doc->open(uri);
+
+      // Get The first subtitle added to the original document
+      Subtitle last_orig_sub = doc->subtitles().get(subtitle_size);
+      Subtitle first_new_subs = doc->subtitles().get_next(last_orig_sub);
+
+      // Now we apply offset
+      if (applying_offset) {
+        SubtitleTime min_gap =
+            cfg::get_int("timing", "min-gap-between-subtitles");
+        SubtitleTime gap = offset - last_orig_sub.get_end();
+        se_dbg_msg(SE_DBG_PLUGINS, "First new %s",
+                   first_new_subs.get_start().str().c_str());
+        se_dbg_msg(SE_DBG_PLUGINS, "Offset %s", offset.str().c_str());
+        se_dbg_msg(SE_DBG_PLUGINS, "Last_orig %s",
+                   last_orig_sub.get_end().str().c_str());
+        se_dbg_msg(SE_DBG_PLUGINS, "Min_gap %s", min_gap.str().c_str());
+        se_dbg_msg(SE_DBG_PLUGINS, "Gap %s", gap.str().c_str());
+        if (gap < min_gap)
+          offset = offset + min_gap - gap;
+
+        for (Subtitle sub = first_new_subs; sub; ++sub) {
+          sub.set_start_and_end(sub.get_start() + offset,
+                                sub.get_end() + offset);
+        }
+      }
+
+      // Make the user life easy by selecting the first new subtitle
+      if (first_new_subs) {
+        doc->subtitles().select(first_new_subs);
+      }
+
+      doc->setFilename(ofile);
+      doc->setFormat(oformat);
+      doc->setCharset(ocharset);
+      doc->finish_command();
+
+      unsigned int subtitles_added = doc->subtitles().size() - subtitle_size;
+
+      doc->flash_message(
+          ngettext("One subtitle has been added to this document.",
+                   "%d subtitles have been added to this document.",
+                   subtitles_added),
+          subtitles_added);
+    } catch (...) {
+      se_dbg_msg(SE_DBG_PLUGINS, "Failed to %s document: %s",
+                 applying_offset ? "join" : "append", uri.c_str());
     }
 
     return true;

--- a/po/bg.po
+++ b/po/bg.po
@@ -1293,8 +1293,8 @@ msgstr "Присъединяване на документ"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 субтитри бяха добавени към документа."
 msgstr[1] "%d субтитри бяха добавени към документа."
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1301,8 +1301,8 @@ msgstr "Document nou"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1284,8 +1284,8 @@ msgstr "Spojit dokument"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Do tohoto dokumentu byl přidán jeden titulek."
 msgstr[1] "Do tohoto dokumentu byly přidány %d titulky."
 msgstr[2] "Do tohoto dokumentu bylo přidáno %d titulků."

--- a/po/da.po
+++ b/po/da.po
@@ -1226,8 +1226,8 @@ msgstr ""
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -1321,8 +1321,8 @@ msgstr "Dokument verbinden"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 Untertitel wurde diesem Dokument hinzugefügt."
 msgstr[1] "%d Untertitel wurde diesem Dokument hinzugefügt."
 

--- a/po/el.po
+++ b/po/el.po
@@ -1303,8 +1303,8 @@ msgstr "Συνένωση εγγράφου"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 υπότιτλος έχει προστεθεί σε αυτό το έγγραφο."
 msgstr[1] "%d υπότιτλοι έχουν προστεθεί σε αυτό το έγγραφο."
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1310,10 +1310,10 @@ msgstr "Join document"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
-msgstr[0] "1 subtitle has been added at this document."
-msgstr[1] "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
+msgstr[0] "One subtitle has been added to this document."
+msgstr[1] "%d subtitles have been added to this document."
 
 #: ../plugins/actions/keyframesmanagement/keyframesgenerator.cc:33
 #: ../plugins/actions/keyframesmanagement/keyframesgeneratorusingframe.cc:34

--- a/po/eo.po
+++ b/po/eo.po
@@ -1290,8 +1290,8 @@ msgstr "Kunligi dokumenton"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 subteksto aldoniĝis al ĉi tiu dokumento."
 msgstr[1] "%d subtekstoj aldoniĝis al ĉi tiu dokumento."
 

--- a/po/es.po
+++ b/po/es.po
@@ -1296,8 +1296,8 @@ msgstr "Unir Documento"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 subtítulo ha sido agregado a este documento."
 msgstr[1] "%d subtítulos han sido agregados a este documento."
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -1255,8 +1255,8 @@ msgstr "Sartu dokumentuan"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "azpititulu 1 gehitu da dokumentuan."
 msgstr[1] "%d azpititulu gehitu dira dokumentuan."
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1324,8 +1324,8 @@ msgstr "Fusionner un document"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 sous-titre à été ajouté à ce document."
 msgstr[1] "%d sous-titres ont été ajoutés à ce document."
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -1309,8 +1309,8 @@ msgstr "Unir un documento"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Engadiuse un subtítulo a este documento."
 msgstr[1] "Engadíronse %d subtítulos a este documento."
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -1258,8 +1258,8 @@ msgstr ""
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -1340,8 +1340,8 @@ msgstr "Unisci documenti"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, fuzzy, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Il sottotitolo %d è stato cancellato con successo."
 msgstr[1] "Il sottotitolo %d è stato cancellato con successo."
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -1275,8 +1275,8 @@ msgstr "Sujungti dokumentą"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Šiame dokumente buvo pridėtas %d subtitras."
 msgstr[1] "Šiame dokumente buvo pridėti %d subtitrai."
 msgstr[2] "Šiame dokumente buvo pridėta %d subtitrų."

--- a/po/nl.po
+++ b/po/nl.po
@@ -1327,8 +1327,8 @@ msgstr "Nieuw document"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1300,8 +1300,8 @@ msgstr "Złącz dokument"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 napis został dodany do tego dokumentu"
 msgstr[1] "%d napisy zostały dodane do tego dokumentu"
 msgstr[2] "%d napisów zostało dodanych do tego dokumentu"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1273,8 +1273,8 @@ msgstr "Une documento"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Foi adicionada 1 legenda a este documento."
 msgstr[1] "Foram adicionadas %d legendas a este documento."
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1278,8 +1278,8 @@ msgstr "Une documento"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Foi adicionada 1 legenda a este documento."
 msgstr[1] "Foram adicionadas %d legendas a este documento."
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1273,8 +1273,8 @@ msgstr "Une documento"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "Foi adicionada 1 legenda a este documento."
 msgstr[1] "Foram adicionadas %d legendas a este documento."
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1303,8 +1303,8 @@ msgstr "Объединить документ"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "1 субтитр был добавлен в документ."
 msgstr[1] "%d субтитров были добавлены в документ."
 msgstr[2] "%d субтитров было добавлено в документ."

--- a/po/sr.po
+++ b/po/sr.po
@@ -1246,8 +1246,8 @@ msgstr ""
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/subtitleeditor.pot
+++ b/po/subtitleeditor.pot
@@ -1209,8 +1209,8 @@ msgstr ""
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1289,8 +1289,8 @@ msgstr "Belgeyi birleştir"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] ""
 "Bu dosyaya 1 altyazı eklendi.\r\n"
 "Bu dosyaya %d altyazı eklendi."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1266,8 +1266,8 @@ msgstr "加入文件"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "%d 条字幕被添加到该文件。"
 
 #: ../plugins/actions/keyframesmanagement/keyframesgenerator.cc:33

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1252,8 +1252,8 @@ msgstr "加入檔案"
 
 #: ../plugins/actions/joindocument/joindocument.cc:142
 #, c-format
-msgid "1 subtitle has been added at this document."
-msgid_plural "%d subtitles have been added at this document."
+msgid "One subtitle has been added to this document."
+msgid_plural "%d subtitles have been added to this document."
 msgstr[0] "%d 條字幕被加入該檔案。"
 
 #: ../plugins/actions/keyframesmanagement/keyframesgenerator.cc:33

--- a/share/menubar.xml
+++ b/share/menubar.xml
@@ -92,7 +92,8 @@
 			<separator/>
 			<placeholder name="split-document"/>
 			<placeholder name="join-document"/>
-			<separator/>
+			<placeholder name="append-document"/>
+            <separator/>
 			<placeholder name="style-editor"/>
 			<separator/>
 			<placeholder name="apply-translation"/>


### PR DESCRIPTION
This adds new action that adds subtitles from another file without changing timecodes at all. This is useful if the subtitles are for the same video, for example if two people were working on the same video and now need to join their separate parts.

Also, the offset of the original Join subtitle actino is not configurable via a dialog. The dialog is also smart, as it offers the duration of video as the default offset if a video is open. When no video is open, the endtime of last subtitle is offered, mimicking current behaviour. Of course, the user can also choose something else.

In practice, when joining subtitles like this, often they will be timed to a different video, that is supposedly going to be joined after the current video.

Also a gramatical fix to translation files is applied.