### PR TITLE
Debugging: enable profiling by default in debug and debug code cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,7 +265,7 @@ fi
 # profile options (default no)
 
 AC_ARG_ENABLE(profile,
-							[AC_HELP_STRING([--enable-profile], [turn on profiling [default=no]])],,
+							[AC_HELP_STRING([--enable-profile], [turn on gprof profiling [default=no]])],,
 							[enable_profile=no])
 
 if test "$enable_profile" = "yes"; then

--- a/docs/subtitleeditor.1
+++ b/docs/subtitleeditor.1
@@ -50,6 +50,11 @@ Show summary of options.
 Show all help options.
 .RE
 .PP
+\fB\-\-help\-debug\fR
+.RS 3n
+Show debug options if debug support was compiled in.
+.RE
+.PP
 \fB\-\-help\-gst\fR
 .RS 3n
 Show GStreamer options.

--- a/plugins/actions/clipboard/clipboard.cc
+++ b/plugins/actions/clipboard/clipboard.cc
@@ -65,35 +65,40 @@ class ClipboardPlugin : public Action {
 
     // actions
     action_group = Gtk::ActionGroup::create("ClipboardPlugin");
-
+    action_group->add(Gtk::Action::create("menu-edit/menu-copy",
+                                          _("Copy"), _("Copy")));
+    // see comment in menubar.cc why we do this (to avoid setting a shortcut)
+    action_group->get_action("menu-edit/menu-copy")->set_stock_id(Gtk::Stock::COPY);
     action_group->add(
         Gtk::Action::create("clipboard-copy", _("_Copy"),
-                            _("Copy selected subtitles to the clipboard")),
+                            _("Copy selected subtitles to the clipboard, making only their text visible to other clipboard-using aplications")),
         sigc::mem_fun(*this, &ClipboardPlugin::on_copy));
-    action_group->add(
-        Gtk::Action::create(
-            "clipboard-cut", _("C_ut"),
-            _("Copy selected subtitles to the clipboard and delete them")),
-        sigc::mem_fun(*this, &ClipboardPlugin::on_cut));
-    action_group->add(
-        Gtk::Action::create("clipboard-paste", _("_Paste"),
-                            _("Paste subtitles from the clipboard AFTER the "
-                              "currently selected subtitle, keeping their duration and gaps between them but setting the start of the first one right after with respect to the minimal gap between subtitles setting )")),
-        sigc::mem_fun(*this, &ClipboardPlugin::on_paste));
-    action_group->add(
+     action_group->add(
         Gtk::Action::create("clipboard-copy-with-timing", _("Copy With Timing"),
                             _("Copy selected subtitles and make their timing "
-                              "visible to text-based applications")),
+                              "visible to other clipboard-using applications")),  Gtk::AccelKey("<Control>c"),
         sigc::mem_fun(*this, &ClipboardPlugin::on_copy_with_timing));
 
-    action_group->add(Gtk::Action::create("menu-edit/menu-paste-special",
-                                          _("Paste Special")));
+    action_group->add(
+        Gtk::Action::create(
+            "clipboard-cut", Gtk::Stock::CUT, _("C_ut"),
+            _("Copy selected subtitles to the clipboard and delete them")), Gtk::AccelKey("<Control>x"),
+        sigc::mem_fun(*this, &ClipboardPlugin::on_cut));
+
+    action_group->add(Gtk::Action::create("menu-edit/menu-paste",
+                                          _("Paste"), _("Paste")));
+    action_group->get_action("menu-edit/menu-paste")->set_stock_id(Gtk::Stock::PASTE);
+    action_group->add(
+        Gtk::Action::create("clipboard-paste",  Gtk::Stock::PASTE, _("_Paste"),
+                            _("Paste subtitles from the clipboard AFTER the "
+                              "currently selected subtitle, keeping their duration and gaps between them but setting the start of the first one right after with respect to the minimal gap between subtitles setting )")),  Gtk::AccelKey("<Control>v"),
+        sigc::mem_fun(*this, &ClipboardPlugin::on_paste));
 
     action_group->add(
         Gtk::Action::create("clipboard-paste-at-player-position",
                             _("Paste At Current Player Position"),
                             _("Paste subtitles from the clipboard AFTER the "
-                              "currently selected subtitle, keeping their duration and gaps between them but setting the start of the first at the current player position")),
+                              "currently selected subtitle, keeping their duration and gaps between them but setting the start of the first at the current player position")), Gtk::AccelKey("<Control><Shift>v"),
         sigc::mem_fun(*this, &ClipboardPlugin::on_paste_at_player_position));
     action_group->add(
         Gtk::Action::create("clipboard-paste-as-new-document",
@@ -137,12 +142,13 @@ class ClipboardPlugin : public Action {
           <menu name='menu-edit' action='menu-edit'>
             <placeholder name='clipboard'>
               <separator/>
-              <menuitem action='clipboard-copy'/>
+              <menu action='menu-edit/menu-copy'>
+                <menuitem action='clipboard-copy'/>
+                <menuitem action='clipboard-copy-with-timing'/>
+              </menu>
               <menuitem action='clipboard-cut'/>
-              <menuitem action='clipboard-paste'/>
-              <separator/>
-              <menuitem action='clipboard-copy-with-timing'/>
-              <menu action='menu-edit/menu-paste-special'>
+              <menu action='menu-edit/menu-paste'>
+                <menuitem action='clipboard-paste'/>
                 <menuitem action='clipboard-paste-at-player-position'/>
                 <menuitem action='clipboard-paste-as-new-document'/>
                 <menuitem action='clipboard-paste-over-text'/>

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -18,26 +18,39 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+
 #include <glibmm/timer.h>
-#include <iostream>
 #include <string>
 #include "debug.h"
 
 static int debug_flags = SE_NO_DEBUG;
 
 // PROFILING
-static bool profiling_enable = false;
+static bool profiling_enable = true;
 static Glib::Timer profiling_timer;
 static double profiling_timer_last = 0.0;
+
+// Helper function to get profiling prefix (returns empty when profiling disabled)
+static std::string get_profiling_prefix() {
+  if (!profiling_enable) {
+    return "";
+  }
+  double seconds = profiling_timer.elapsed();
+  std::string time_since_program_start = std::to_string(seconds);
+  std::string time_it_took_to_execute_since_last_dbg_msg = std::to_string(seconds - profiling_timer_last);
+  std::string prefix = "[" + time_since_program_start + " (" + time_it_took_to_execute_since_last_dbg_msg + ")]";
+  profiling_timer_last = seconds;
+  return prefix;
+}
 
 void __se_dbg_init(int flags) {
   debug_flags = flags;
 
-  if (G_UNLIKELY(debug_flags & SE_DBG_PROFILING) &&
-      debug_flags != SE_NO_DEBUG) {
-    profiling_enable = true;
+  // Profiling enabled by default, disable if "debug-no-profiling" is set
+  if (G_UNLIKELY(debug_flags & SE_DBG_NO_PROFILING) && debug_flags != SE_NO_DEBUG)
+    profiling_enable = false;
+  else
     profiling_timer.start();
-  }
 }
 
 bool se_dbg_check_flags(int flag) {
@@ -48,23 +61,15 @@ bool se_dbg_check_flags(int flag) {
 }
 
 void __se_dbg(int flag, const gchar* file, const gint line,
-              const gchar* fonction) {
+              const gchar* function) {
   if (G_UNLIKELY(debug_flags & flag) || G_UNLIKELY(debug_flags & SE_DBG_ALL)) {
-    if (profiling_enable) {
-      double seconds = profiling_timer.elapsed();
-
-      g_print("[%f (%f)] %s:%d (%s)\n", seconds, seconds - profiling_timer_last,
-              file, line, fonction);
-      profiling_timer_last = seconds;
-    } else {
-      g_print("%s:%d (%s)\n", file, line, fonction);
-    }
-
+    std::string prefix = get_profiling_prefix();
+    g_print("%s %s:%d (%s)\n", prefix.c_str(), file, line, function);
     fflush(stdout);
   }
 }
 
-void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* fonction,
+void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* function,
                   const char* format, ...) {
   if (G_UNLIKELY(debug_flags & flag) || G_UNLIKELY(debug_flags & SE_DBG_ALL)) {
     va_list args;
@@ -75,19 +80,25 @@ void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* fonction,
     va_start(args, format);
     msg = g_strdup_vprintf(format, args);
     va_end(args);
-
-    if (profiling_enable) {
-      double seconds = profiling_timer.elapsed();
-
-      g_print("[%f (%f)] %s:%d (%s) %s\n", seconds,
-              seconds - profiling_timer_last, file, line, fonction, msg);
-      profiling_timer_last = seconds;
-    } else {
-      g_print("%s:%d (%s) %s\n", file, line, fonction, msg);
-    }
-
+    std::string prefix = get_profiling_prefix();
+    g_print("%s %s:%d (%s) %s\n", prefix.c_str(), file, line, function, msg);
     fflush(stdout);
 
     g_free(msg);
   }
 }
+
+// Also accept std::string and Glib::ustring as input, though without the fancy formatting
+// FIXME some modern c++ thing like std::string_view or c++20
+// concept StringLike = std::convertible_to<T, std::string_view>;
+// would make it accept any string-like thing
+void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* function,
+                  const std::string& message) {
+  if (G_UNLIKELY(debug_flags & flag) || G_UNLIKELY(debug_flags & SE_DBG_ALL)) {
+    std::string prefix = get_profiling_prefix();
+    g_print("%s %s:%d (%s) %s\n", prefix.c_str(), file, line, function, message.c_str());
+    fflush(stdout);
+  }
+}
+
+

--- a/src/debug.h
+++ b/src/debug.h
@@ -26,6 +26,7 @@
 
 #include <glib.h>
 #include <stdio.h>
+#include <string>
 
 enum SE_DBG_MESSAGE_FLAG {
   SE_NO_DEBUG = 0,
@@ -43,7 +44,7 @@ enum SE_DBG_MESSAGE_FLAG {
   SE_DBG_UTILITY = 1 << 9,
   SE_DBG_COMMAND = 1 << 10,
   SE_DBG_PLUGINS = 1 << 11,
-  SE_DBG_PROFILING = 1 << 12,
+  SE_DBG_NO_PROFILING = 1 << 12,
 
   SE_DBG_ALL = 1 << 20
 };
@@ -52,10 +53,13 @@ void __se_dbg_init(int flags);
 
 bool se_dbg_check_flags(int flags);
 
-void __se_dbg(int flag, const gchar* file, gint line, const gchar* fonction);
+void __se_dbg(int flag, const gchar* file, gint line, const gchar* function);
 
-void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* fonction,
+void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* function,
                   const char* string, ...);
+
+void __se_dbg_msg(int flag, const gchar* file, gint line, const gchar* function,
+                  const std::string& message);
 
 #ifdef DEBUG
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -62,6 +62,10 @@ int main(int argc, char *argv[]) {
     Glib::OptionContext context(_(" — edit subtitles files"));
     context.set_main_group(options);
 
+#ifdef DEBUG
+    context.add_group(options.get_debug_group());
+#endif
+
     Glib::OptionGroup gst_group(gst_init_get_option_group());
     context.add_group(gst_group);
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -24,7 +24,14 @@
 #include "i18n.h"
 
 OptionGroup::OptionGroup()
-    : Glib::OptionGroup("subtitleeditor...", "description...", "help...") {
+    : Glib::OptionGroup("subtitleeditor", _("Application Options"),
+                        _("Edit subtitle files"))
+#ifdef DEBUG
+      ,
+      debug_group("debug", _("Debug Options"), _("Show debug-related options"))
+#endif
+
+{
   se_dbg(SE_DBG_APP);
 
   set_translation_domain(GETTEXT_PACKAGE);
@@ -89,27 +96,33 @@ OptionGroup::OptionGroup()
 
 #ifdef DEBUG
 
-#define add_debug_option(name, value) \
-  {                                   \
-    value = false;                    \
-    Glib::OptionEntry e;              \
-    e.set_long_name("debug-" name);   \
-    add_entry(e, value);              \
+#define add_debug_option(name, value, desc) \
+  {                                         \
+    value = false;                          \
+    Glib::OptionEntry e;                    \
+    e.set_long_name("debug-" name);         \
+    e.set_description(desc);                \
+    debug_group.add_entry(e, value);        \
   }
 
-  add_debug_option("all", debug_all);
-  add_debug_option("app", debug_app);
-  add_debug_option("view", debug_view);
-  add_debug_option("io", debug_io);
-  add_debug_option("search", debug_search);
-  add_debug_option("regex", debug_regex);
-  add_debug_option("video-player", debug_video_player);
-  add_debug_option("spell-checking", debug_spell_checking);
-  add_debug_option("waveform", debug_waveform);
-  add_debug_option("utility", debug_utility);
-  add_debug_option("command", debug_command);
-  add_debug_option("plugins", debug_plugins);
-  add_debug_option("profiling", debug_profiling);
+  add_debug_option("all", debug_all,
+                   "Shows all debug output (in effect like passing all options "
+                   "below except no-profiling)");
+  add_debug_option("no-profiling", debug_no_profiling,
+                   "Disable timestamps of functions call in debug output");
+  add_debug_option("app", debug_app, "Application debug messages");
+  add_debug_option("view", debug_view, "View/UI debug messages");
+  add_debug_option("io", debug_io, "File I/O debug messages");
+  add_debug_option("search", debug_search, "Search debug messages");
+  add_debug_option("regex", debug_regex, "Regex debug messages");
+  add_debug_option("video-player", debug_video_player,
+                   "Video player debug messages");
+  add_debug_option("spell-checking", debug_spell_checking,
+                   "Spell checker debug messages");
+  add_debug_option("waveform", debug_waveform, "Waveform debug messages");
+  add_debug_option("utility", debug_utility, "Utility debug messages");
+  add_debug_option("command", debug_command, "Command system debug");
+  add_debug_option("plugins", debug_plugins, "Plugins debug messages");
 
 #undef add_debug_option
 
@@ -120,8 +133,12 @@ int OptionGroup::get_debug_flags() {
   int flags = 0;
 
 #ifdef DEBUG
-  if (debug_profiling)
-    flags |= SE_DBG_PROFILING;
+
+  // This is here first so that "--debug-all --debug-no-profiling" does not show
+  // timestamps
+  if (debug_no_profiling)
+    flags |= SE_DBG_NO_PROFILING;
+
   if (debug_all) {
     flags |= SE_DBG_ALL;
     return flags;

--- a/src/options.h
+++ b/src/options.h
@@ -31,6 +31,12 @@ class OptionGroup : public Glib::OptionGroup {
 
   int get_debug_flags();
 
+#ifdef DEBUG
+  Glib::OptionGroup& get_debug_group() {
+    return debug_group;
+  }
+#endif
+
  public:
   std::vector<Glib::ustring> files;
   std::vector<Glib::ustring> files_list;  // simple file (glibmm Bug #526831)
@@ -42,6 +48,8 @@ class OptionGroup : public Glib::OptionGroup {
   Glib::ustring keyframes;  // keyframes file location
 
 #ifdef DEBUG
+  Glib::OptionGroup debug_group;
+
   bool debug_all;
   bool debug_app;
   bool debug_view;
@@ -54,6 +62,6 @@ class OptionGroup : public Glib::OptionGroup {
   bool debug_utility;
   bool debug_command;
   bool debug_plugins;
-  bool debug_profiling;
+  bool debug_no_profiling;
 #endif  // DEBUG
 };


### PR DESCRIPTION
This also makes debug-help show when --help-all is called or --help-debug, not cluttering the normal help view. Also refactored the code a bit to avoid duplication, added descriptions etc.