### PR TITLE
Fix crash on mouse move and click in empty waveform renderer with unsaved non-empty file

### DIFF
--- a/src/we/waveformeditor.cc
+++ b/src/we/waveformeditor.cc
@@ -738,7 +738,7 @@ bool WaveformEditor::on_button_release_event_renderer(GdkEventButton * /*ev*/) {
 bool WaveformEditor::on_motion_notify_event_renderer(GdkEventMotion *ev) {
   se_dbg(SE_DBG_WAVEFORM);
 
-  if (!(has_renderer() && has_document()))
+  if (!(has_renderer() && has_document() && has_waveform()))
     return true;
 
   Subtitle subtitle = document()->subtitles().get_first_selected();

--- a/src/we/waveformrenderer.cc
+++ b/src/we/waveformrenderer.cc
@@ -135,6 +135,8 @@ int WaveformRenderer::get_end_area() {
 // return the time of the position in the area
 // time is in msec (SubtitleTime.totalmsecs)
 long WaveformRenderer::get_time_by_pos(int pos) {
+  if (!m_waveform)
+    return 0;
   float width = static_cast<float>(widget()->get_width()) * zoom();
   float percent = static_cast<float>(pos) / width;
   return static_cast<long>(m_waveform->get_duration() * percent);


### PR DESCRIPTION
Fixes https://github.com/subtitleeditor/subtitleeditor/issues/41