### PR TITLE
Clipboard: Fix GTK warnings

### DIFF
--- a/plugins/actions/clipboard/clipboard.cc
+++ b/plugins/actions/clipboard/clipboard.cc
@@ -133,6 +133,7 @@ class ClipboardPlugin : public Action {
     Glib::RefPtr<Gtk::UIManager> ui = get_ui_manager();
 
     ui_id = ui->new_merge_id();
+    ui_id_edit = ui->new_merge_id();
 
     ui->insert_action_group(action_group);
 
@@ -162,7 +163,7 @@ class ClipboardPlugin : public Action {
       </ui>
     )";
 
-    ui_id = ui->add_ui_from_string(submenu_edit);
+    ui_id_edit = ui->add_ui_from_string(submenu_edit);
 
     Glib::ustring submenu_selection = R"(
       <ui>
@@ -176,7 +177,7 @@ class ClipboardPlugin : public Action {
       </ui>
     )";
 
-    ui_id = ui->add_ui_from_string(submenu_selection);
+    ui_id_selection = ui->add_ui_from_string(submenu_selection);
     // clear the clipdoc
     clear_clipdoc();
 
@@ -226,7 +227,8 @@ class ClipboardPlugin : public Action {
     clear_clipdoc();
     clear_pastedoc();
 
-    ui->remove_ui(ui_id);
+    ui->remove_ui(ui_id_selection);
+    ui->remove_ui(ui_id_edit);
     ui->remove_action_group(action_group);
   }
 
@@ -965,7 +967,8 @@ class ClipboardPlugin : public Action {
   }
 
  protected:
-  Gtk::UIManager::ui_merge_id ui_id;
+  Gtk::UIManager::ui_merge_id ui_id_edit;
+  Gtk::UIManager::ui_merge_id ui_id_selection;
   Glib::RefPtr<Gtk::ActionGroup> action_group;
 
   // data store


### PR DESCRIPTION
Without this, upon closing the app, we were getting these warnings:

(subtitleeditor:593939): Gtk-WARNING **: 22:37:14.927: menu-edit/menu-copy: missing action menu-edit/menu-copy
(subtitleeditor:593939): Gtk-WARNING **: 22:37:14.927: clipboard-cut: missing action clipboard-cut
(subtitleeditor:593939): Gtk-WARNING **: 22:37:14.927: menu-edit/menu-paste: missing action menu-edit/menu-paste

We were overwriting ui_id before, so when we called ui->remove_ui(ui_id) in deactivate(), we only removed the second UI merge (the selection menu), but not the first one (the edit menu). The edit menu items remained in the UI but their actions got removed, causing the warnings.
